### PR TITLE
Fix typo

### DIFF
--- a/models/PCN.py
+++ b/models/PCN.py
@@ -8,7 +8,7 @@ class PCN(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.number_fine = config.num_pred
-        self.encoder_channal = config.encoder_channel
+        self.encoder_channel = config.encoder_channel
         grid_size = 4 # set default
         self.grid_size = grid_size
         assert self.number_fine % grid_size**2 == 0


### PR DESCRIPTION
Fix typo to fix following error:
```
AttributeError: PCN: 'PCN' object has no attribute 'encoder_channel'
```
