### PR TITLE
Update Readme and Dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,19 @@ bash install.sh
 The solution for a common bug in chamfer distance installation can be found in Issue [#6](https://github.com/yuxumin/PoinTr/issues/6)
 ```
 # PointNet++
-pip install "git+git://github.com/erikwijmans/Pointnet2_PyTorch.git#egg=pointnet2_ops&subdirectory=pointnet2_ops_lib"
+pip install "git+https://github.com/erikwijmans/Pointnet2_PyTorch.git#egg=pointnet2_ops&subdirectory=pointnet2_ops_lib"
 # GPU kNN
 pip install --upgrade https://github.com/unlimblue/KNN_CUDA/releases/download/0.2/KNN_CUDA-0.2-py3-none-any.whl
 ```
+
+Note: If you still get `ModuleNotFoundError: No module named 'gridding'` or something similar then run these steps
+
+```
+    1. cd into extensions/Module (eg extensions/gridding)
+    2. run `python setup.py install`
+```
+
+That will fix the `ModuleNotFoundError`.
 
 
 ### Dataset

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ opencv-python
 pyyaml
 scipy
 tensorboardX
-timm==0.4.5  # if you're on newer versions of python / mamba / conda, installing may throw an error. installing timm open3d seems to work 
+timm==0.4.5  # if you're on newer versions of python / mamba / conda, installing may throw an error. installing latest timm seems to work 
 tqdm
 transforms3d
 einops

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,12 @@ easydict
 h5py
 matplotlib
 numpy
-open3d==0.9
+open3d==0.9 # if you're on newer versions of python / mamba / conda, installing may throw an error. installing latest open3d seems to work 
 opencv-python
 pyyaml
 scipy
 tensorboardX
-timm==0.4.5 
+timm==0.4.5  # if you're on newer versions of python / mamba / conda, installing may throw an error. installing timm open3d seems to work 
 tqdm
 transforms3d
+einops


### PR DESCRIPTION
This PR adds some instructions for newcomers to download and run this file.

1. PointNet++ path is fixed. Github removed `git://`: https://github.blog/2021-09-01-improving-git-protocol-security-github/ and as a result installation hangs up. switching to https:// fixes this (please verify any typos with url). 

2. Added instructions to installation of extensions manually if bash install.sh fails 

3. Added einops as dependency and also added a comment regarding version numbers of open3d==0.9, timm==0.4.5 , these packages don't exist while on mamba so I thought it would be good to note that the latest current versions of them work with the code 